### PR TITLE
added first connection check, ready for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 </p>
 <p align="center">
     <a href="https://github.com/PaxJaromeMalues/ubuntu-server-autoinstall-iso-repacker/releases/latest">
-        <img src="https://img.shields.io/badge/Version-1.0.0-green.svg" alt="Version">
+        <img src="https://img.shields.io/badge/Version-1.1.0-green.svg" alt="Version">
     </a>
     <a href="https://github.com/PaxJaromeMalues/ubuntu-server-autoinstall-iso-repacker/issues">
         <img src="https://img.shields.io/github/issues-raw/PaxJaromeMalues/ubuntu-server-autoinstall-iso-repacker.svg?label=Issues" alt="Issues">


### PR DESCRIPTION
Connection check via `netcat` instead of `ping` to circumvent ICMP protocol filtering.